### PR TITLE
Add unsupported wheels burn-down chart

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
 
+      - name: Run unit tests
+        run: |
+          python -m unittest
+
       - name: Fetch latest packages data and build the website
         run: |
           make generate

--- a/generate.py
+++ b/generate.py
@@ -1,10 +1,12 @@
 from svg_wheel import generate_svg_wheel
 from utils import (
     annotate_wheels,
+    fetch_deployed_result,
     get_top_packages,
+    get_package_wheel_status,
+    load_history,
     remove_irrelevant_packages,
     save_to_file,
-    fetch_old_result,
 )
 
 TO_CHART = 1000
@@ -12,13 +14,16 @@ TO_CHART = 1000
 
 def main(to_chart: int = TO_CHART) -> None:
     # Fetch current status
-    old_packages = fetch_old_result()
-    if old_packages is None:
-        print(" ! Skipping old packages")
-        old_packages = {}
+    deployed_result = fetch_deployed_result()
+    if deployed_result is None:
+        raise RuntimeError(
+            "Could not fetch the deployed results; refusing to discard wheel history"
+        )
+    old_packages = get_package_wheel_status(deployed_result)
+    history = load_history(deployed_result)
     packages = remove_irrelevant_packages(get_top_packages(), to_chart)
     annotate_wheels(packages, old_packages)
-    save_to_file(packages, "results.json")
+    save_to_file(packages, "results.json", history)
     generate_svg_wheel(packages, to_chart)
 
 

--- a/history.json
+++ b/history.json
@@ -1,0 +1,2347 @@
+[
+ {
+  "date": "2025-04-10",
+  "unsupported": 124,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-11",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-12",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-13",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-14",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-15",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-16",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-17",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-18",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-19",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-20",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-21",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-22",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-23",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-24",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-25",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-26",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-27",
+  "unsupported": 123,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-28",
+  "unsupported": 124,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-29",
+  "unsupported": 124,
+  "total": 1000
+ },
+ {
+  "date": "2025-04-30",
+  "unsupported": 122,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-01",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-02",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-03",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-04",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-05",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-06",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-07",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-08",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-09",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-10",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-11",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-12",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-13",
+  "unsupported": 120,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-14",
+  "unsupported": 120,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-15",
+  "unsupported": 120,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-16",
+  "unsupported": 119,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-17",
+  "unsupported": 119,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-18",
+  "unsupported": 117,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-19",
+  "unsupported": 117,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-20",
+  "unsupported": 117,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-21",
+  "unsupported": 117,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-22",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-23",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-24",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-25",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-26",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-27",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-28",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-29",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-30",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-05-31",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-01",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-02",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-03",
+  "unsupported": 115,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-04",
+  "unsupported": 118,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-05",
+  "unsupported": 118,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-06",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-07",
+  "unsupported": 121,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-08",
+  "unsupported": 120,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-09",
+  "unsupported": 120,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-10",
+  "unsupported": 116,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-11",
+  "unsupported": 114,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-12",
+  "unsupported": 114,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-13",
+  "unsupported": 113,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-14",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-15",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-16",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-17",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-18",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-19",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-20",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-21",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-22",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-23",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-24",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-25",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-26",
+  "unsupported": 112,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-27",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-28",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-29",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-06-30",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-01",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-02",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-03",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-04",
+  "unsupported": 111,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-05",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-06",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-07",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-08",
+  "unsupported": 107,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-09",
+  "unsupported": 107,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-10",
+  "unsupported": 107,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-11",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-12",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-13",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-14",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-15",
+  "unsupported": 106,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-16",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-17",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-18",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-19",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-20",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-21",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-22",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-23",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-24",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-25",
+  "unsupported": 105,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-26",
+  "unsupported": 104,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-27",
+  "unsupported": 103,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-28",
+  "unsupported": 103,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-29",
+  "unsupported": 103,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-30",
+  "unsupported": 100,
+  "total": 1000
+ },
+ {
+  "date": "2025-07-31",
+  "unsupported": 100,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-01",
+  "unsupported": 96,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-02",
+  "unsupported": 96,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-03",
+  "unsupported": 97,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-04",
+  "unsupported": 97,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-05",
+  "unsupported": 96,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-06",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-07",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-08",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-09",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-10",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-11",
+  "unsupported": 95,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-12",
+  "unsupported": 94,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-13",
+  "unsupported": 94,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-14",
+  "unsupported": 94,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-15",
+  "unsupported": 93,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-16",
+  "unsupported": 93,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-17",
+  "unsupported": 92,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-18",
+  "unsupported": 91,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-19",
+  "unsupported": 91,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-20",
+  "unsupported": 91,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-21",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-22",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-23",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-24",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-25",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-26",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-27",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-28",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-29",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-30",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-08-31",
+  "unsupported": 90,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-01",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-02",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-03",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-04",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-05",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-06",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-07",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-08",
+  "unsupported": 89,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-09",
+  "unsupported": 88,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-10",
+  "unsupported": 88,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-11",
+  "unsupported": 86,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-12",
+  "unsupported": 85,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-13",
+  "unsupported": 85,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-14",
+  "unsupported": 85,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-15",
+  "unsupported": 85,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-16",
+  "unsupported": 85,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-17",
+  "unsupported": 84,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-18",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-19",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-20",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-21",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-22",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-23",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-24",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-25",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-26",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-27",
+  "unsupported": 80,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-28",
+  "unsupported": 79,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-29",
+  "unsupported": 79,
+  "total": 1000
+ },
+ {
+  "date": "2025-09-30",
+  "unsupported": 79,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-01",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-02",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-03",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-04",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-05",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-06",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-07",
+  "unsupported": 83,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-08",
+  "unsupported": 82,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-09",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-10",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-11",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-12",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-13",
+  "unsupported": 81,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-14",
+  "unsupported": 80,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-15",
+  "unsupported": 80,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-16",
+  "unsupported": 79,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-17",
+  "unsupported": 79,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-18",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-19",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-20",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-21",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-22",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-23",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-24",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-25",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-26",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-27",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-28",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-29",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-30",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-10-31",
+  "unsupported": 77,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-01",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-02",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-03",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-04",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-05",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-06",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-07",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-08",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-09",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-10",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-11",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-12",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-13",
+  "unsupported": 75,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-14",
+  "unsupported": 74,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-15",
+  "unsupported": 73,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-16",
+  "unsupported": 73,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-17",
+  "unsupported": 73,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-18",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-19",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-20",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-21",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-22",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-23",
+  "unsupported": 71,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-24",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-25",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-26",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-27",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-28",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-29",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-11-30",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-01",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-02",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-03",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-04",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-05",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-06",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-07",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-08",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-09",
+  "unsupported": 72,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-10",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-11",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-12",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-13",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-14",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-15",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-16",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-17",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-18",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-19",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-20",
+  "unsupported": 70,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-21",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-22",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-23",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-24",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-25",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-26",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-27",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-28",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-29",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-30",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2025-12-31",
+  "unsupported": 69,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-01",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-02",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-03",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-04",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-05",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-06",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-07",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-08",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-09",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-10",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-11",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-12",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-13",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-14",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-15",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-16",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-17",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-18",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-19",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-20",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-21",
+  "unsupported": 68,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-22",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-23",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-24",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-25",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-26",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-27",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-28",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-29",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-30",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-01-31",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-01",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-02",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-03",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-04",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-05",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-06",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-07",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-08",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-09",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-10",
+  "unsupported": 67,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-11",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-12",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-13",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-14",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-15",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-16",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-17",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-18",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-19",
+  "unsupported": 66,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-20",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-21",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-22",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-23",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-24",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-25",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-27",
+  "unsupported": 65,
+  "total": 1000
+ },
+ {
+  "date": "2026-02-28",
+  "unsupported": 64,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-01",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-02",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-03",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-04",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-05",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-06",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-07",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-08",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-09",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-10",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-11",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-12",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-13",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-14",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-15",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-16",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-17",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-18",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-19",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-20",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-21",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-22",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-23",
+  "unsupported": 61,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-24",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-25",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-26",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-27",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-28",
+  "unsupported": 64,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-29",
+  "unsupported": 64,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-30",
+  "unsupported": 64,
+  "total": 1000
+ },
+ {
+  "date": "2026-03-31",
+  "unsupported": 63,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-01",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-02",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-03",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-04",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-05",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-06",
+  "unsupported": 62,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-07",
+  "unsupported": 61,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-08",
+  "unsupported": 61,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-09",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-10",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-11",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-12",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-13",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-14",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-15",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-16",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-17",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-18",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-19",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-20",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-21",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-22",
+  "unsupported": 60,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-23",
+  "unsupported": 61,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-24",
+  "unsupported": 61,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-25",
+  "unsupported": 59,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-26",
+  "unsupported": 59,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-27",
+  "unsupported": 59,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-28",
+  "unsupported": 59,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-29",
+  "unsupported": 59,
+  "total": 1000
+ },
+ {
+  "date": "2026-04-30",
+  "unsupported": 58,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-01",
+  "unsupported": 55,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-02",
+  "unsupported": 55,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-03",
+  "unsupported": 55,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-04",
+  "unsupported": 55,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-05",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-06",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-07",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-08",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-09",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-10",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-11",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-13",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-14",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-15",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-16",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-17",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-18",
+  "unsupported": 56,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-19",
+  "unsupported": 57,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-20",
+  "unsupported": 55,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-21",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-22",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-23",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-24",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-25",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-27",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-28",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-29",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-30",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-05-31",
+  "unsupported": 54,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-01",
+  "unsupported": 53,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-02",
+  "unsupported": 52,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-03",
+  "unsupported": 52,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-04",
+  "unsupported": 51,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-05",
+  "unsupported": 51,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-06",
+  "unsupported": 51,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-07",
+  "unsupported": 51,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-08",
+  "unsupported": 51,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-09",
+  "unsupported": 50,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-10",
+  "unsupported": 49,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-11",
+  "unsupported": 49,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-12",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-13",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-14",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-15",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-16",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-17",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-18",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-19",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-20",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-21",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-22",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-23",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-24",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-25",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-26",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-27",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-28",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-29",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-06-30",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-01",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-02",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-03",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-04",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-05",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-06",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-07",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-08",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-10",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-11",
+  "unsupported": 47,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-12",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-13",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-14",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-15",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-16",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-17",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-18",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-19",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-20",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-21",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-22",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-23",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-24",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-25",
+  "unsupported": 48,
+  "total": 1000
+ },
+ {
+  "date": "2026-07-26",
+  "unsupported": 48,
+  "total": 1000
+ }
+]

--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
         a.btn:last-child{border-bottom-width: 1px; border-bottom-left-radius: 5px; border-bottom-right-radius: 5px;}
         pre {text-align: left;}
         footer{text-align: center;}
+        .chart-container {
+            height: 320px;
+            margin-bottom: 15px;
+            position: relative;
+        }
         .text-default {
             color: #777;
         }
@@ -59,6 +64,13 @@
             <div class="col-sm">
             <h1 id="wheels">💪 Windows/ARM64 Python Wheels</h1>
                 <object data="wheel.svg" type="image/svg+xml" width="380" height="380" class="d-block mx-auto"></object>
+                <section id="burndown-section" hidden>
+                    <h2 id="burndown">Unsupported wheels burn-down</h2>
+                    <p>The daily number of the top 1,000 packages that still need a Windows ARM64 or pure-Python wheel.</p>
+                    <div class="chart-container">
+                        <canvas id="burndown-chart" role="img" aria-label="Burn-down chart of packages without supported wheels"></canvas>
+                    </div>
+                </section>
                 <h2 id="what-wheels">What are wheels?</h2>
                 <p><a href="https://pypi.org/project/wheel">Wheels</a> are <a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/">the standard binary format</a> for distributing Python packages. See <a href="https://pythonwheels.com/">pythonwheels.com</a>.</p>
                 <h2 id="what">Why do we need Windows/ARM64 Wheels?</h2>
@@ -107,6 +119,7 @@
     </div>
     <a href="https://github.com/tonybaloney/windows-arm64-wheels" class="github-corner" aria-label="View source on GitHub"><svg width="80" class="github-icon" height="80" viewBox="0 0 250 250" fill="#fff" color="#151513" style="position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.3/angular.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
 
     <script>
         var app = angular.module('app', [])
@@ -115,6 +128,82 @@
                 $scope.last_update = res.data.last_update;
                 $scope.packages = res.data.data;
                 $scope.selectedFilter = ''; // Default to All
+                const history = res.data.history || [];
+
+                if (history.length && typeof Chart !== 'undefined') {
+                    const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    const chartColour = darkMode ? '#ccc' : '#666';
+                    const gridColour = darkMode ? '#333' : '#ddd';
+                    document.getElementById('burndown-section').hidden = false;
+                    new Chart(document.getElementById('burndown-chart'), {
+                        type: 'line',
+                        data: {
+                            labels: history.map(point => point.date),
+                            datasets: [{
+                                label: 'Packages without supported wheels',
+                                data: history.map(point => point.unsupported),
+                                borderColor: '#f0ad00',
+                                backgroundColor: 'rgba(255, 193, 7, 0.2)',
+                                borderWidth: 2,
+                                fill: true,
+                                pointRadius: 0,
+                                pointHitRadius: 8,
+                                tension: 0.15
+                            }]
+                        },
+                        options: {
+                            animation: false,
+                            maintainAspectRatio: false,
+                            interaction: {
+                                intersect: false,
+                                mode: 'index'
+                            },
+                            plugins: {
+                                legend: {
+                                    labels: {
+                                        color: chartColour
+                                    }
+                                },
+                                tooltip: {
+                                    callbacks: {
+                                        label: function (context) {
+                                            const point = history[context.dataIndex];
+                                            const percent = (point.unsupported / point.total * 100).toFixed(1);
+                                            return `${point.unsupported} of ${point.total} packages (${percent}%)`;
+                                        }
+                                    }
+                                }
+                            },
+                            scales: {
+                                x: {
+                                    grid: {
+                                        color: gridColour
+                                    },
+                                    ticks: {
+                                        autoSkip: true,
+                                        color: chartColour,
+                                        maxTicksLimit: 8,
+                                        maxRotation: 0
+                                    }
+                                },
+                                y: {
+                                    beginAtZero: true,
+                                    grid: {
+                                        color: gridColour
+                                    },
+                                    ticks: {
+                                        color: chartColour
+                                    },
+                                    title: {
+                                        color: chartColour,
+                                        display: true,
+                                        text: 'Unsupported packages'
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
 
                 // Define filters
                 $scope.filters = [

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,62 @@
+import datetime
+import json
+import os
+import tempfile
+import unittest
+
+from utils import load_history, update_history
+
+
+class HistoryTests(unittest.TestCase):
+    def test_seed_contains_every_historic_day(self):
+        history = load_history(None)
+
+        self.assertEqual(len(history), 469)
+        self.assertEqual(history[0]["date"], "2025-04-10")
+        self.assertEqual(history[-1]["date"], "2026-07-26")
+        self.assertEqual({point["total"] for point in history}, {1000})
+
+    def test_deployed_history_excludes_smaller_tracking_period(self):
+        deployed = {
+            "history": [
+                {"date": "2025-04-09", "unsupported": 41, "total": 360},
+                {"date": "2026-07-27", "unsupported": 48, "total": 1000},
+            ]
+        }
+
+        self.assertEqual(load_history(deployed), deployed["history"][1:])
+
+    def test_legacy_deployment_falls_back_to_seed(self):
+        expected = [{"date": "2025-04-10", "unsupported": 124, "total": 1000}]
+        with tempfile.TemporaryDirectory() as directory:
+            file_name = os.path.join(directory, "history.json")
+            with open(file_name, "w") as history_file:
+                json.dump(expected, history_file)
+
+            self.assertEqual(load_history({"data": []}, file_name), expected)
+
+    def test_same_day_run_replaces_existing_point(self):
+        history = [
+            {"date": "2026-07-27", "unsupported": 2, "total": 3},
+            {"date": "2026-07-26", "unsupported": 3, "total": 3},
+        ]
+        packages = [
+            {"css_class": "warning"},
+            {"css_class": "success"},
+            {"css_class": "default"},
+        ]
+        now = datetime.datetime(2026, 7, 27, tzinfo=datetime.timezone.utc)
+
+        updated = update_history(history, packages, now)
+
+        self.assertEqual(
+            updated,
+            [
+                {"date": "2026-07-26", "unsupported": 3, "total": 3},
+                {"date": "2026-07-27", "unsupported": 1, "total": 3},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,12 @@ import requests_cache
 
 
 BASE_URL = "https://pypi.org/pypi"
+HISTORY_FILE = "history.json"
+HISTORY_PACKAGE_TOTAL = 1000
+DEPLOYED_RESULTS_URL = (
+    "https://github.com/tonybaloney/windows-arm64-wheels/raw/refs/heads/gh-pages/"
+    "results.json"
+)
 
 DEPRECATED_PACKAGES = {
     "BeautifulSoup",
@@ -26,14 +32,83 @@ def get_json_url(package_name):
     return BASE_URL + "/" + package_name + "/json"
 
 
-def fetch_old_result():
-    url = "https://github.com/tonybaloney/windows-arm64-wheels/raw/refs/heads/gh-pages/results.json"
-    response = SESSION.get(url)
+def fetch_deployed_result():
+    response = SESSION.get(DEPLOYED_RESULTS_URL)
     if response.status_code != 200:
-        print(" ! Skipping " + url)
+        print(" ! Skipping " + DEPLOYED_RESULTS_URL)
         return None
-    data = response.json()
-    return {d["name"]: int(d.get("wheel_enabled", 0)) for d in data["data"]}
+    return response.json()
+
+
+def get_package_wheel_status(result):
+    if result is None:
+        return {}
+    return {d["name"]: int(d.get("wheel_enabled", 0)) for d in result["data"]}
+
+
+def fetch_old_result():
+    result = fetch_deployed_result()
+    if result is None:
+        return None
+    return get_package_wheel_status(result)
+
+
+def validate_history(history):
+    if not isinstance(history, list):
+        raise ValueError("Wheel history must be a list")
+
+    validated = []
+    for point in history:
+        if not isinstance(point, dict):
+            raise ValueError("Each wheel history point must be an object")
+
+        date = point.get("date")
+        unsupported = point.get("unsupported")
+        total = point.get("total")
+        try:
+            datetime.date.fromisoformat(date)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"Invalid wheel history date: {date!r}") from error
+
+        if (
+            not isinstance(unsupported, int)
+            or isinstance(unsupported, bool)
+            or not isinstance(total, int)
+            or isinstance(total, bool)
+            or unsupported < 0
+            or total < 0
+            or unsupported > total
+        ):
+            raise ValueError(f"Invalid wheel history counts for {date}")
+
+        validated.append({"date": date, "unsupported": unsupported, "total": total})
+
+    return validated
+
+
+def load_history(deployed_result, file_name=HISTORY_FILE):
+    if deployed_result is not None and "history" in deployed_result:
+        history = deployed_result["history"]
+    else:
+        with open(file_name) as history_file:
+            history = json.load(history_file)
+
+    return [
+        point
+        for point in validate_history(history)
+        if point["total"] == HISTORY_PACKAGE_TOTAL
+    ]
+
+
+def update_history(history, packages, now):
+    point = {
+        "date": now.date().isoformat(),
+        "unsupported": sum(package["css_class"] == "warning" for package in packages),
+        "total": len(packages),
+    }
+    by_date = {item["date"]: item for item in validate_history(history)}
+    by_date[point["date"]] = point
+    return [by_date[date] for date in sorted(by_date)]
 
 
 def annotate_wheels(packages, old_packages):
@@ -115,15 +190,14 @@ def remove_irrelevant_packages(packages, limit):
     return active_packages[:limit]
 
 
-def save_to_file(packages, file_name):
+def save_to_file(packages, file_name, history=None):
     now = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+    result = {
+        "data": packages,
+        "last_update": now.strftime("%A, %d %B %Y, %X %Z"),
+    }
+    if history is not None:
+        result["history"] = update_history(history, packages, now)
+
     with open(file_name, "w") as f:
-        f.write(
-            json.dumps(
-                {
-                    "data": packages,
-                    "last_update": now.strftime("%A, %d %B %Y, %X %Z"),
-                },
-                indent=1,
-            )
-        )
+        f.write(json.dumps(result, indent=1))


### PR DESCRIPTION
## Summary
- add a burn-down chart for unsupported wheels among the top 1,000 PyPI packages
- seed daily history from the 1,000-package period beginning 10 April 2025
- preserve and update history through the existing scheduled deployment job
- add unit coverage for migration, filtering, and same-day reruns

## Checks
- `python -m unittest`
- `pre-commit run --files history.json index.html test_utils.py utils.py --show-diff-on-failure`
- full 1,000-package site generation